### PR TITLE
Emit comma between CTEs in non-compact WITH formatting

### DIFF
--- a/src/formatter/select.rs
+++ b/src/formatter/select.rs
@@ -1593,7 +1593,12 @@ impl<'a> Formatter<'a> {
                 }
 
                 if !self.config.compact_ctes {
-                    lines.push(")".to_string());
+                    let is_last = i == ctes.len() - 1;
+                    lines.push(if is_last {
+                        ")".to_string()
+                    } else {
+                        "),".to_string()
+                    });
                 }
             }
 

--- a/tests/fixtures/dbt/select_cte_multi.expected
+++ b/tests/fixtures/dbt/select_cte_multi.expected
@@ -1,0 +1,18 @@
+with
+
+a as (
+
+    select 1 as x
+
+),
+b as (
+
+    select 2 as y
+
+)
+
+select *
+
+from
+    a,
+    b;

--- a/tests/fixtures/dbt/select_cte_multi.sql
+++ b/tests/fixtures/dbt/select_cte_multi.sql
@@ -1,0 +1,1 @@
+WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS y) SELECT * FROM a, b

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -256,6 +256,11 @@ fn dbt_select_cte() {
     run_fixture(Style::Dbt, "select_cte");
 }
 
+#[test]
+fn dbt_select_cte_multi() {
+    run_fixture(Style::Dbt, "select_cte_multi");
+}
+
 // ── GitLab fixtures ─────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- `format_with_clause_left` was unconditionally pushing `)` after each CTE body, dropping the comma separator between CTEs whenever `compact_ctes` was off (most visibly in the `dbt` style).
- Closing line is now `),` for non-final CTEs and `)` for the last, matching the comma handling already present in the compact-CTE branch.
- Added a minimal multi-CTE fixture for the `dbt` style as a regression test.

## Repro (before fix)

Input:
```sql
WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS y) SELECT * FROM a, b
```
Formatting with `Style::Dbt` produced `)\nb as (` (no comma) — invalid SQL.

## Test plan
- [x] `cargo test` (73 pass; new `dbt_select_cte_multi`)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of multiple Common Table Expressions (CTEs) in WITH clauses to correctly position separators—commas and parentheses—between individual CTE definitions when using left-aligned query formatting.

* **Tests**
  * Added comprehensive test cases to validate multi-CTE formatting scenarios and ensure accurate separator placement and formatting consistency across supported SQL styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->