### PR TITLE
Fix multi-word type name truncation in :: casts

### DIFF
--- a/src/formatter/expr.rs
+++ b/src/formatter/expr.rs
@@ -1112,6 +1112,32 @@ impl<'a> Formatter<'a> {
         self.text(node).to_string()
     }
 
+    /// Flatten the wrapper nodes the grammar inserts for character/bit types
+    /// (`CharacterWithLength > character > kw_character + opt_varying`, etc.)
+    /// so the keyword, VARYING qualifier, and length token are all visible to
+    /// the single-pass type renderer below.
+    fn flatten_type_children(&self, node: Node<'a>) -> Vec<Node<'a>> {
+        const WRAPPERS: &[&str] = &[
+            "CharacterWithLength",
+            "CharacterWithoutLength",
+            "character",
+            "BitWithLength",
+            "BitWithoutLength",
+            "bit",
+            "opt_varying",
+        ];
+        let mut out = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.is_named() && WRAPPERS.contains(&child.kind()) {
+                out.extend(self.flatten_type_children(child));
+            } else {
+                out.push(child);
+            }
+        }
+        out
+    }
+
     fn format_typename_inner(&self, node: Node<'a>) -> String {
         // Get the base type name.
         let mut base = String::new();
@@ -1119,8 +1145,7 @@ impl<'a> Formatter<'a> {
         let mut extra_keywords = Vec::new();
         let mut timezone_keywords = Vec::new();
 
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
+        for child in self.flatten_type_children(node) {
             if child.is_named() {
                 match child.kind() {
                     "kw_integer" | "kw_int" | "kw_smallint" | "kw_bigint" | "kw_real"
@@ -1168,6 +1193,19 @@ impl<'a> Formatter<'a> {
                     }
                     "opt_type_modifiers" => {
                         modifiers = self.format_type_modifiers(child);
+                    }
+                    "Iconst" => {
+                        // Bare length token inside CharacterWithLength.
+                        modifiers = format!("({})", self.text(child).trim());
+                    }
+                    "expr_list" => {
+                        // Parenthesized length/precision args (e.g. BitWithLength
+                        // renders the length as ( expr_list )).
+                        let items: Vec<String> = flatten_list(child, "expr_list")
+                            .iter()
+                            .map(|e| self.format_expr(*e))
+                            .collect();
+                        modifiers = format!("({})", items.join(", "));
                     }
                     "attrs" => {
                         base.push_str(&self.format_attrs(child));

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -109,3 +109,31 @@ fn typed_literal_constants_river() {
         assert_eq!(result, expected, "\nInput: {sql}\nGot:\n{result}");
     }
 }
+
+#[test]
+fn cast_multiword_type_names() {
+    // Regression: multi-word type names in :: casts must not be truncated
+    // (e.g. `::character varying` previously dropped `varying`).
+    let cases = [
+        (
+            "SELECT a::character varying",
+            "SELECT a::CHARACTER VARYING;",
+        ),
+        ("SELECT a::varchar(50)", "SELECT a::VARCHAR(50);"),
+        ("SELECT a::char(10)", "SELECT a::CHAR(10);"),
+        (
+            "SELECT a::character varying(50)",
+            "SELECT a::CHARACTER VARYING(50);",
+        ),
+        ("SELECT a::double precision", "SELECT a::DOUBLE PRECISION;"),
+        ("SELECT a::bit varying(8)", "SELECT a::BIT VARYING(8);"),
+        (
+            "SELECT a::timestamp with time zone",
+            "SELECT a::TIMESTAMP WITH TIME ZONE;",
+        ),
+    ];
+    for (sql, expected) in cases {
+        let result = format(sql, Style::River).unwrap();
+        assert_eq!(result, expected, "\nInput: {sql}\nGot:\n{result}");
+    }
+}


### PR DESCRIPTION
## Summary

`'Free'::character varying` formatted to `'Free'::CHARACTER` — the trailing words were dropped — and `::bit varying(8)` mis-rendered the length as the base type (`::8 BIT VARYING`).

The `Character`/`Bit` type nodes nest their keyword, `VARYING` qualifier, and length under wrapper nodes the single-pass type renderer never descended into:
- `CharacterWithLength > character > kw_character + opt_varying`, length as a bare `Iconst`
- `BitWithLength > kw_bit + opt_varying`, length as a parenthesized `expr_list`

Fix: flatten those wrapper nodes before rendering, and treat a bare `Iconst` or a parenthesized `expr_list` as the length modifier.

## Verification

New regression test (`cast_multiword_type_names`) covers `character varying`, `varchar(n)`, `char(n)`, `character varying(n)`, `double precision`, `bit varying(n)`, and `timestamp with time zone`. Full suite green.

This was found while evaluating a `pg_dump`/ruleutils format style (deparser output uses these casts heavily), but it's an independent correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)