### PR TITLE
ci: update actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Get crates.io token via trusted publishing
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@v1.0.4
         id: auth
 
       - name: Publish to crates.io

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -26,7 +26,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary

GitHub is forcing Node 20 JS actions to Node 24 on 2026-06-16 and removing Node 20 on 2026-09-16. Update the actions that still ran on Node 20:

- `actions/cache` `v4` → `v5` (node24; inputs unchanged — `path`/`key`/`restore-keys`)
- `rust-lang/crates-io-auth-action` `v1` → `v1.0.4` (node24)

`actions/checkout@v5` and `dtolnay/rust-toolchain` (composite) were already fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline tooling to use newer versions of build and deployment actions for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->