### PR TITLE
Fix dropped PL/pgSQL EXCEPTION handlers and RAISE USING options

### DIFF
--- a/src/formatter/plpgsql.rs
+++ b/src/formatter/plpgsql.rs
@@ -388,17 +388,7 @@ impl<'a> Formatter<'a> {
                         parts.push(self.kw("USING"));
                     }
                     "raise_option" => {
-                        let mut oc = child.walk();
-                        let mut opt_kw = String::new();
-                        let mut opt_expr = String::new();
-                        for c in child.named_children(&mut oc) {
-                            if c.kind().starts_with("kw_") {
-                                opt_kw = self.kw(self.text(c).trim());
-                            } else if c.kind() == "sql_expression" {
-                                opt_expr = self.text(c).trim().to_string();
-                            }
-                        }
-                        parts.push(format!("{opt_kw} = {opt_expr}"));
+                        parts.push(self.format_raise_option(child));
                     }
                     _ => {}
                 }
@@ -414,6 +404,21 @@ impl<'a> Formatter<'a> {
         }
 
         lines.push(format!("{indent}{};", parts.join(" ")));
+    }
+
+    // Formats a single `RAISE ... USING` option as `KEYWORD = expression`.
+    fn format_raise_option(&self, node: Node<'a>) -> String {
+        let mut cursor = node.walk();
+        let mut opt_kw = String::new();
+        let mut opt_expr = String::new();
+        for c in node.named_children(&mut cursor) {
+            if c.kind().starts_with("kw_") {
+                opt_kw = self.kw(self.text(c).trim());
+            } else if c.kind() == "sql_expression" {
+                opt_expr = self.text(c).trim().to_string();
+            }
+        }
+        format!("{opt_kw} = {opt_expr}")
     }
 
     fn format_exception_sect(&self, node: Node<'a>, indent_level: usize, lines: &mut Vec<String>) {

--- a/src/formatter/plpgsql.rs
+++ b/src/formatter/plpgsql.rs
@@ -384,6 +384,22 @@ impl<'a> Formatter<'a> {
                     "sql_expression" => {
                         parts.push(self.text(child).trim().to_string());
                     }
+                    "kw_using" => {
+                        parts.push(self.kw("USING"));
+                    }
+                    "raise_option" => {
+                        let mut oc = child.walk();
+                        let mut opt_kw = String::new();
+                        let mut opt_expr = String::new();
+                        for c in child.named_children(&mut oc) {
+                            if c.kind().starts_with("kw_") {
+                                opt_kw = self.kw(self.text(c).trim());
+                            } else if c.kind() == "sql_expression" {
+                                opt_expr = self.text(c).trim().to_string();
+                            }
+                        }
+                        parts.push(format!("{opt_kw} = {opt_expr}"));
+                    }
                     _ => {}
                 }
             } else {
@@ -403,20 +419,22 @@ impl<'a> Formatter<'a> {
     fn format_exception_sect(&self, node: Node<'a>, indent_level: usize, lines: &mut Vec<String>) {
         let indent = "  ".repeat(indent_level);
         let mut cursor = node.walk();
+        // Each handler is wrapped in a `proc_exception` node containing the
+        // WHEN conditions and the handler body (`proc_sect`).
         for child in node.named_children(&mut cursor) {
-            match child.kind() {
-                "proc_conditions" => {
-                    let cond_text = self.text(child).trim();
-                    lines.push(format!(
-                        "{indent}{} {cond_text} {}",
-                        self.kw("WHEN"),
-                        self.kw("THEN")
-                    ));
-                }
-                "proc_sect" => {
-                    self.format_proc_sect(child, indent_level + 1, lines);
-                }
-                _ => {}
+            if child.kind() != "proc_exception" {
+                continue;
+            }
+            if let Some(conds) = child.find_child("proc_conditions") {
+                let cond_text = self.text(conds).trim();
+                lines.push(format!(
+                    "{indent}{} {cond_text} {}",
+                    self.kw("WHEN"),
+                    self.kw("THEN")
+                ));
+            }
+            if let Some(proc) = child.find_child("proc_sect") {
+                self.format_proc_sect(proc, indent_level + 1, lines);
             }
         }
     }

--- a/tests/plpgsql_test.rs
+++ b/tests/plpgsql_test.rs
@@ -73,6 +73,36 @@ fn for_over_query_keeps_query() {
     assert!(result.contains("RETURN NEXT r;"), "\nGot:\n{result}");
 }
 
+// Regression (#26): the EXCEPTION handler body was dropped, leaving a bare
+// EXCEPTION keyword, because the code looked for proc_conditions/proc_sect as
+// direct children of exception_sect instead of inside each proc_exception node.
+#[test]
+fn exception_handler_body_preserved() {
+    let body = "BEGIN NULL; EXCEPTION WHEN OTHERS THEN RAISE; END";
+    let result = format_plpgsql(body, Style::Aweber).unwrap();
+    let expected = "\
+BEGIN
+  NULL;
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE;
+END;";
+    assert_eq!(result, expected, "\nGot:\n{result}");
+}
+
+// Regression (#32): RAISE ... USING options (ERRCODE, MESSAGE, ...) were
+// dropped because only raise_level/string_literal/sql_expression were matched.
+#[test]
+fn raise_using_options_preserved() {
+    let body = "BEGIN RAISE EXCEPTION 'bad %', x USING ERRCODE = '22000', MESSAGE = 'boom'; END";
+    let result = format_plpgsql(body, Style::Aweber).unwrap();
+    let expected = "\
+BEGIN
+  RAISE EXCEPTION 'bad %', x USING ERRCODE = '22000', MESSAGE = 'boom';
+END;";
+    assert_eq!(result, expected, "\nGot:\n{result}");
+}
+
 // Regression: format_plpgsql falls back to SQL formatting when the body is not
 // PL/pgSQL (e.g. a LANGUAGE sql function body), rather than erroring.
 #[test]

--- a/tests/plpgsql_test.rs
+++ b/tests/plpgsql_test.rs
@@ -103,6 +103,19 @@ END;";
     assert_eq!(result, expected, "\nGot:\n{result}");
 }
 
+// Regression (#32): additional RAISE ... USING option keywords (DETAIL, HINT)
+// are preserved alongside ERRCODE.
+#[test]
+fn raise_using_detail_hint_options_preserved() {
+    let body = "BEGIN RAISE EXCEPTION 'bad' USING DETAIL = 'd', HINT = 'h', ERRCODE = '22000'; END";
+    let result = format_plpgsql(body, Style::Aweber).unwrap();
+    let expected = "\
+BEGIN
+  RAISE EXCEPTION 'bad' USING DETAIL = 'd', HINT = 'h', ERRCODE = '22000';
+END;";
+    assert_eq!(result, expected, "\nGot:\n{result}");
+}
+
 // Regression: format_plpgsql falls back to SQL formatting when the body is not
 // PL/pgSQL (e.g. a LANGUAGE sql function body), rather than erroring.
 #[test]


### PR DESCRIPTION
## Summary

Fixes two PL/pgSQL formatting bugs where constructs were silently dropped from the output.

## Problem

- **#26** — An EXCEPTION handler was reduced to a bare `EXCEPTION` keyword with the `WHEN ... THEN` condition and handler body discarded. The grammar wraps each handler in a `proc_exception` node, but `format_exception_sect` scanned `exception_sect`'s direct named children for `proc_conditions`/`proc_sect`, which never matched.
- **#32** — `RAISE ... USING ...` options (`ERRCODE`, `MESSAGE`, etc.) were dropped. `format_stmt_raise` only matched `raise_level`/`string_literal`/`sql_expression`, ignoring `kw_using` and each `raise_option`.

## Solution

- `format_exception_sect` now iterates into each `proc_exception` node and renders its `proc_conditions` and `proc_sect`.
- `format_stmt_raise` now handles `kw_using` and each `raise_option` (keyword `=` expression), supporting multiple comma-separated options.
- Added inline regression tests to `tests/plpgsql_test.rs` for both cases.

`just check` (fmt, clippy `-D warnings`, tests) passes.

Fixes #26
Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of PL/pgSQL `RAISE` statements so `USING` options are preserved and displayed consistently.
  * Fixed formatting of `EXCEPTION` handlers to keep the handler body intact and correctly place `WHEN ... THEN` blocks.
* **Tests**
  * Added regression coverage for exception handler formatting and `RAISE ... USING` option preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->