### PR TITLE
Add PostgreSQL 19 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-postgres"
-version = "1.2.4"
+version = "19.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2552ec55c9813f358da70926587b2bbfceff6a7b75456b2ddf8abfb223dcf3a7"
+checksum = "c6291b3eae19ae4bb4ac3955a42fe7ed0505d62544073ebeea3156fdc1d57a8c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "development-tools"]
 
 [dependencies]
 tree-sitter = "0.26"
-tree-sitter-postgres = "19.0.0-beta.2"
+tree-sitter-postgres = "=19.0.0-beta.2"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "development-tools"]
 
 [dependencies]
 tree-sitter = "0.26"
-tree-sitter-postgres = "1.2.4"
+tree-sitter-postgres = "19.0.0-beta.2"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ publish-dry:
 publish:
     cargo publish
 
-# Regenerate Style::PgDump fixtures from a throwaway PostgreSQL cluster
+# Regenerate Style::PgDump fixtures from a throwaway PostgreSQL container (needs Docker)
 gen-pgdump-fixtures:
     bash tests/fixtures/pg_dump/generate.sh
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     ports:
-      - "5599:5432"
+      - "127.0.0.1:5599:5432"
     tmpfs:
       - /var/lib/postgresql
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,29 @@
+# Throwaway PostgreSQL cluster for regenerating the Style::PgDump fixtures.
+#
+# Loads tests/fixtures/pg_dump/schema.sql on first boot, then generate.sh
+# captures the deparser output. Data lives in tmpfs, so `docker compose down`
+# leaves nothing behind. Nothing global on the host is touched.
+#
+#   docker compose up -d --wait     # or: just gen-pgdump-fixtures
+#
+# Pinned to 19beta2 to match the tree-sitter-postgres 19.0b2 grammar and to
+# capture deparser output for PostgreSQL 19 features; a different major version
+# may deparse these objects differently.
+services:
+  postgres:
+    image: postgres:19beta2
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5599:5432"
+    tmpfs:
+      - /var/lib/postgresql
+    volumes:
+      - ./tests/fixtures/pg_dump/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/src/formatter/expr.rs
+++ b/src/formatter/expr.rs
@@ -644,6 +644,20 @@ impl<'a> Formatter<'a> {
             "func_expr" => {
                 if let Some(app) = node.find_child("func_application") {
                     let mut result = self.format_func(app);
+                    // Trailing clauses appear in grammar order:
+                    // WITHIN GROUP, FILTER, RESPECT/IGNORE NULLS (PG19), OVER.
+                    if let Some(wg) = node.find_child("within_group_clause") {
+                        result.push(' ');
+                        result.push_str(&self.format_within_group_clause(wg));
+                    }
+                    if let Some(filter) = node.find_child("filter_clause") {
+                        result.push(' ');
+                        result.push_str(&self.format_filter_clause(filter));
+                    }
+                    if let Some(nt) = node.find_child("null_treatment") {
+                        result.push(' ');
+                        result.push_str(&self.format_null_treatment(nt));
+                    }
                     // Check for OVER clause at the func_expr level
                     // (window functions like RANK() OVER (...)).
                     if let Some(over) = node.find_child("over_clause") {
@@ -824,6 +838,35 @@ impl<'a> Formatter<'a> {
             }
         }
         parts.join("")
+    }
+
+    /// Format a `WITHIN GROUP (ORDER BY ...)` clause on an ordered-set or
+    /// hypothetical-set aggregate (e.g. `percentile_cont`).
+    fn format_within_group_clause(&self, node: Node<'a>) -> String {
+        let order = node
+            .find_child("sort_clause")
+            .map(|sc| self.format_sort_clause_inline(sc))
+            .unwrap_or_default();
+        format!("{} ({order})", self.kw_pair("WITHIN", "GROUP"))
+    }
+
+    /// Format a `FILTER (WHERE <condition>)` aggregate filter clause.
+    fn format_filter_clause(&self, node: Node<'a>) -> String {
+        let cond = node
+            .find_child_any(&["a_expr", "c_expr"])
+            .map(|e| self.format_expr(e))
+            .unwrap_or_default();
+        format!("{} ({} {cond})", self.kw("FILTER"), self.kw("WHERE"))
+    }
+
+    /// Format a `null_treatment` node: `RESPECT NULLS` or `IGNORE NULLS` (PG19).
+    fn format_null_treatment(&self, node: Node<'a>) -> String {
+        let leading = if node.has_child("kw_ignore") {
+            self.kw("IGNORE")
+        } else {
+            self.kw("RESPECT")
+        };
+        format!("{leading} {}", self.kw("NULLS"))
     }
 
     fn format_over_clause(&self, node: Node<'a>) -> String {
@@ -1424,8 +1467,405 @@ impl<'a> Formatter<'a> {
         self.text(node).to_string()
     }
 
+    // ── GRAPH_TABLE (SQL/PGQ property graphs, PG19) ──────────────────────
+    //
+    // `GRAPH_TABLE (graph MATCH <pattern> COLUMNS (<exprs>)) [AS alias]`.
+    // The graph pattern is a contiguous token stream (`(a)-[e]->(b)`) whose
+    // vertex/edge elements concatenate without separators, while the contents
+    // inside each `(...)`/`[...]` are space-separated. Rendered inline.
+
+    fn format_graph_table(&self, node: Node<'a>) -> String {
+        let mut graph_name = String::new();
+        let mut pattern = String::new();
+        let mut columns = String::new();
+        let mut alias = String::new();
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            match child.kind() {
+                "qualified_name" => graph_name = self.format_expr(child),
+                "graph_pattern" => pattern = self.format_graph_pattern(child),
+                "labeled_expr_list" => columns = self.format_labeled_expr_list(child),
+                "opt_alias_clause" | "alias_clause" => alias = self.format_alias(child),
+                _ => {}
+            }
+        }
+        // Indented block: the graph name, MATCH and COLUMNS each get their own
+        // line one indent level in; the closing paren de-dents to the
+        // `GRAPH_TABLE` column. Inner lines are indented relative to column 0
+        // so the FROM layout (river_line / left-aligned) can re-anchor them.
+        let indent = self.config.indent;
+        let close = if alias.is_empty() {
+            ")".to_string()
+        } else {
+            format!(") {alias}")
+        };
+        format!(
+            "{gt} (\n{indent}{graph_name}\n{indent}{match_kw} {pattern}\n{indent}{cols_kw} ({columns})\n{close}",
+            gt = self.kw("GRAPH_TABLE"),
+            match_kw = self.kw("MATCH"),
+            cols_kw = self.kw("COLUMNS"),
+        )
+    }
+
+    fn format_graph_pattern(&self, node: Node<'a>) -> String {
+        let mut parts = Vec::new();
+        if let Some(list) = node.find_child("path_pattern_list") {
+            let items = flatten_list(list, "path_pattern_list");
+            let formatted: Vec<_> = items.iter().map(|i| self.render_path(*i)).collect();
+            parts.push(formatted.join(", "));
+        }
+        if let Some(wc) = node.find_child("where_clause") {
+            parts.push(self.format_graph_where(wc));
+        }
+        parts.join(" ")
+    }
+
+    /// Render a path element node, concatenating vertices, edges, and
+    /// quantifiers without separators (e.g. `(a)-[e]->(b){2}`).
+    fn render_path(&self, node: Node<'a>) -> String {
+        match node.kind() {
+            "path_primary" => self.format_path_primary(node),
+            "opt_graph_pattern_quantifier" => {
+                let mut cursor = node.walk();
+                node.children(&mut cursor).map(|c| self.text(c)).collect()
+            }
+            // path_pattern / path_pattern_expression / path_term / path_factor
+            // are structural wrappers whose children concatenate directly.
+            _ => {
+                let mut cursor = node.walk();
+                node.named_children(&mut cursor)
+                    .map(|c| self.render_path(c))
+                    .collect()
+            }
+        }
+    }
+
+    fn format_path_primary(&self, node: Node<'a>) -> String {
+        let mut cursor = node.walk();
+        let children: Vec<Node> = node.children(&mut cursor).collect();
+        let named: Vec<usize> = children
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_named())
+            .map(|(i, _)| i)
+            .collect();
+        // Bare connectors like `->`, `-`, `<-` have no named children.
+        if named.is_empty() {
+            return children.iter().map(|c| self.text(*c)).collect();
+        }
+        let first = named[0];
+        let last = *named.last().unwrap();
+        // Delimiters/arrows around the content glue directly (`-[`, `]->`, `(`).
+        let prefix: String = children[..first].iter().map(|c| self.text(*c)).collect();
+        let suffix: String = children[last + 1..].iter().map(|c| self.text(*c)).collect();
+        let inner: Vec<String> = named
+            .iter()
+            .map(|&i| self.render_path_inner(children[i]))
+            .collect();
+        format!("{prefix}{}{suffix}", inner.join(" "))
+    }
+
+    /// Render the space-separated contents inside a vertex/edge pattern:
+    /// an element variable, an `IS <label>` test, and/or a `WHERE <cond>`.
+    fn render_path_inner(&self, node: Node<'a>) -> String {
+        match node.kind() {
+            "opt_colid" => node
+                .find_child("ColId")
+                .map(|c| self.text(c).to_string())
+                .unwrap_or_default(),
+            "opt_is_label_expression" => {
+                let label = node
+                    .find_child("label_expression")
+                    .map(|l| self.format_label_expression(l))
+                    .unwrap_or_default();
+                format!("{} {label}", self.kw("IS"))
+            }
+            "where_clause" => self.format_graph_where(node),
+            "path_pattern_expression" => self.render_path(node),
+            _ => self.text(node).to_string(),
+        }
+    }
+
+    fn format_label_expression(&self, node: Node<'a>) -> String {
+        match node.kind() {
+            // `A | B` label alternation.
+            "label_disjunction" => {
+                let mut cursor = node.walk();
+                let parts: Vec<_> = node
+                    .named_children(&mut cursor)
+                    .map(|c| self.format_label_expression(c))
+                    .collect();
+                parts.join(" | ")
+            }
+            "label_term" => self.text(node).to_string(),
+            // `label_expression` wraps a single label_term or label_disjunction.
+            _ => {
+                let mut cursor = node.walk();
+                match node.named_children(&mut cursor).next() {
+                    Some(child) => self.format_label_expression(child),
+                    None => self.text(node).to_string(),
+                }
+            }
+        }
+    }
+
+    fn format_graph_where(&self, node: Node<'a>) -> String {
+        let cond = node
+            .find_child_any(&["a_expr", "c_expr"])
+            .map(|e| self.format_expr(e))
+            .unwrap_or_default();
+        format!("{} {cond}", self.kw("WHERE"))
+    }
+
+    pub(crate) fn format_labeled_expr_list(&self, node: Node<'a>) -> String {
+        let items = flatten_list(node, "labeled_expr_list");
+        let formatted: Vec<_> = items.iter().map(|i| self.format_labeled_expr(*i)).collect();
+        formatted.join(", ")
+    }
+
+    fn format_labeled_expr(&self, node: Node<'a>) -> String {
+        let expr = node
+            .find_child_any(&["a_expr", "c_expr"])
+            .map(|e| self.format_expr(e))
+            .unwrap_or_default();
+        if let Some(label) = node.find_child("ColLabel") {
+            format!("{expr} {} {}", self.kw("AS"), self.text(label))
+        } else {
+            expr
+        }
+    }
+
+    // ── CREATE PROPERTY GRAPH (SQL/PGQ, PG19) ────────────────────────────
+
+    /// Format a `CREATE PROPERTY GRAPH` statement with its VERTEX/EDGE TABLES
+    /// clauses laid out one element definition per line, like CREATE TABLE.
+    pub(crate) fn format_create_prop_graph_stmt(&self, node: Node<'a>) -> String {
+        let name = node
+            .find_child("qualified_name")
+            .map(|n| self.format_expr(n))
+            .unwrap_or_default();
+        let mut header = self.kw("CREATE");
+        if let Some(temp) = node.find_child("OptTemp") {
+            header.push(' ');
+            header.push_str(&self.render_graph_inline(temp));
+        }
+        header.push_str(&format!(
+            " {} {} {name}",
+            self.kw("PROPERTY"),
+            self.kw("GRAPH")
+        ));
+        let mut lines = vec![header];
+        for (clause, synonym, list) in [
+            (
+                "opt_vertex_tables_clause",
+                "vertex_synonym",
+                "vertex_table_list",
+            ),
+            ("opt_edge_tables_clause", "edge_synonym", "edge_table_list"),
+        ] {
+            if let Some(inner) = node
+                .find_child(clause)
+                .and_then(|c| c.find_child_any(&["vertex_tables_clause", "edge_tables_clause"]))
+            {
+                self.format_graph_tables_clause(inner, synonym, list, "", &mut lines);
+            }
+        }
+        lines.join("\n")
+    }
+
+    pub(crate) fn format_alter_prop_graph_stmt(&self, node: Node<'a>) -> String {
+        let name = node
+            .find_child("qualified_name")
+            .map(|n| self.format_expr(n))
+            .unwrap_or_default();
+        // Only the `ADD ... TABLES` forms carry vertex/edge table clauses; give
+        // those the same structured block layout as CREATE. The other forms
+        // (DROP TABLES, ALTER ... TABLE ... {ADD,DROP,ALTER} LABEL/PROPERTIES)
+        // are short and render on one line via the keyword-casing walker.
+        let has_tables =
+            node.has_child("vertex_tables_clause") || node.has_child("edge_tables_clause");
+        if !has_tables {
+            return self.render_graph_inline(node);
+        }
+        let add = format!("{} ", self.kw("ADD"));
+        let mut lines = vec![format!(
+            "{} {} {} {name}",
+            self.kw("ALTER"),
+            self.kw("PROPERTY"),
+            self.kw("GRAPH")
+        )];
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            match child.kind() {
+                "vertex_tables_clause" => self.format_graph_tables_clause(
+                    child,
+                    "vertex_synonym",
+                    "vertex_table_list",
+                    &add,
+                    &mut lines,
+                ),
+                "edge_tables_clause" => self.format_graph_tables_clause(
+                    child,
+                    "edge_synonym",
+                    "edge_table_list",
+                    &add,
+                    &mut lines,
+                ),
+                _ => {}
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn format_graph_tables_clause(
+        &self,
+        clause: Node<'a>,
+        synonym_kind: &str,
+        list_kind: &str,
+        lead: &str,
+        lines: &mut Vec<String>,
+    ) {
+        let indent = self.config.indent;
+        let synonym = clause
+            .find_child(synonym_kind)
+            .map(|s| self.kw(self.text(s)))
+            .unwrap_or_default();
+        lines.push(format!("{indent}{lead}{synonym} {} (", self.kw("TABLES")));
+        if let Some(list) = clause.find_child(list_kind) {
+            let defs = flatten_list(list, list_kind);
+            if self.config.river {
+                self.graph_defs_aligned(&defs, lines);
+            } else {
+                // pg_dump and the other left-aligned styles put each element on
+                // one line. pg_dump's 4-space indent yields the 8-space element
+                // indent that pg_get_propgraphdef emits, so this is idempotent.
+                self.graph_defs_simple(&defs, lines);
+            }
+        }
+        lines.push(format!("{indent})"));
+    }
+
+    /// One element per line, no column alignment (non-river left-aligned styles).
+    fn graph_defs_simple(&self, defs: &[Node<'a>], lines: &mut Vec<String>) {
+        let elem = self.config.indent.repeat(2);
+        let last = defs.len().saturating_sub(1);
+        for (i, def) in defs.iter().enumerate() {
+            let comma = if i < last { "," } else { "" };
+            lines.push(format!("{elem}{}{comma}", self.render_graph_inline(*def)));
+        }
+    }
+
+    /// River-family layout: one element per line with each field
+    /// (name, KEY, SOURCE, DESTINATION, LABEL/PROPERTIES) padded into an
+    /// aligned column, like the CREATE TABLE column/type/constraint alignment.
+    fn graph_defs_aligned(&self, defs: &[Node<'a>], lines: &mut Vec<String>) {
+        let elem = self.config.indent.repeat(2);
+        let rows: Vec<[String; 5]> = defs.iter().map(|d| self.graph_element_cells(*d)).collect();
+        // Column widths over the fields present in at least one element.
+        let mut widths = [0usize; 5];
+        for row in &rows {
+            for (c, cell) in row.iter().enumerate() {
+                widths[c] = widths[c].max(cell.chars().count());
+            }
+        }
+        let active: Vec<usize> = (0..5).filter(|&c| widths[c] > 0).collect();
+        let last_row = rows.len().saturating_sub(1);
+        for (i, row) in rows.iter().enumerate() {
+            let mut line = elem.clone();
+            for (j, &c) in active.iter().enumerate() {
+                if j + 1 == active.len() {
+                    line.push_str(&row[c]);
+                } else {
+                    // Pad the field to its column width and separate with a
+                    // single space, exactly as CREATE TABLE's column/type
+                    // alignment does (see render_aligned_column in stmt.rs).
+                    let pad = widths[c] - row[c].chars().count();
+                    line.push_str(&row[c]);
+                    line.push_str(&" ".repeat(pad + 1));
+                }
+            }
+            let mut line = line.trim_end().to_string();
+            if i < last_row {
+                line.push(',');
+            }
+            lines.push(line);
+        }
+    }
+
+    /// Split an element definition into its five aligned columns:
+    /// name (with any alias), KEY, SOURCE, DESTINATION, LABEL/PROPERTIES.
+    /// Absent fields are empty strings.
+    fn graph_element_cells(&self, def: Node<'a>) -> [String; 5] {
+        let mut cells: [String; 5] = Default::default();
+        let mut cursor = def.walk();
+        for child in def.named_children(&mut cursor) {
+            match child.kind() {
+                "qualified_name" => cells[0] = self.format_expr(child),
+                "opt_propgraph_table_alias" => {
+                    cells[0].push(' ');
+                    cells[0].push_str(&self.render_graph_inline(child));
+                }
+                "opt_graph_table_key_clause" => cells[1] = self.render_graph_inline(child),
+                "source_vertex_table" => cells[2] = self.render_graph_inline(child),
+                "destination_vertex_table" => cells[3] = self.render_graph_inline(child),
+                "opt_element_table_label_and_properties" => {
+                    cells[4] = self.render_graph_inline(child)
+                }
+                _ => {}
+            }
+        }
+        cells
+    }
+
+    /// Render a property-graph clause node inline, casing keyword leaves and
+    /// gluing punctuation. Used for element table definitions, which mix
+    /// identifiers, `LABEL`/`SOURCE`/`DESTINATION`/`KEY` keywords, and lists.
+    fn render_graph_inline(&self, node: Node<'a>) -> String {
+        let kind = node.kind();
+        if kind.starts_with("kw_") {
+            return self.kw(self.text(node));
+        }
+        match kind {
+            "qualified_name" => return self.format_expr(node),
+            "labeled_expr_list" => return self.format_labeled_expr_list(node),
+            "name" | "ColId" | "columnref" | "identifier" | "quoted_identifier" => {
+                return self.text(node).to_string();
+            }
+            _ => {}
+        }
+        let mut cursor = node.walk();
+        let children: Vec<Node> = node.children(&mut cursor).collect();
+        if children.is_empty() {
+            return self.text(node).to_string();
+        }
+        let mut out = String::new();
+        for child in children {
+            let piece = self.render_graph_inline(child);
+            if piece.is_empty() {
+                continue;
+            }
+            if out.is_empty() {
+                out.push_str(&piece);
+                continue;
+            }
+            let tok = self.text(child);
+            let last = out.chars().last().unwrap_or(' ');
+            if tok == ")" || tok == "," || last == '(' {
+                out.push_str(&piece);
+            } else {
+                out.push(' ');
+                out.push_str(&piece);
+            }
+        }
+        out
+    }
+
     /// Format a table reference (for FROM clause), returning the table name with alias.
     pub(crate) fn format_table_ref(&self, node: Node<'a>) -> String {
+        // GRAPH_TABLE (...) SQL/PGQ property-graph query (PG19).
+        if node.has_child("kw_graph_table") {
+            return self.format_graph_table(node);
+        }
         let mut parts = Vec::new();
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {

--- a/src/formatter/pgdump.rs
+++ b/src/formatter/pgdump.rs
@@ -50,6 +50,10 @@ impl<'a> Formatter<'a> {
         match inner.kind() {
             "SelectStmt" => Ok(format!("{};", self.pgdump_select(inner, 0))),
             "CreateFunctionStmt" => Ok(self.pgdump_create_function(inner)),
+            // pg_dump emits pg_get_propgraphdef's layout (one element per line)
+            // terminated with a semicolon, like any dumped statement.
+            "CreatePropGraphStmt" => Ok(format!("{};", self.format_create_prop_graph_stmt(inner))),
+            "AlterPropGraphStmt" => Ok(format!("{};", self.format_alter_prop_graph_stmt(inner))),
             // Out of scope: reproduce verbatim so deparser output still
             // round-trips and nothing is mangled.
             _ => Ok(self.text(inner).trim().to_string()),

--- a/src/formatter/stmt.rs
+++ b/src/formatter/stmt.rs
@@ -33,6 +33,8 @@ impl<'a> Formatter<'a> {
                 "CreateTableAsStmt" | "CreateMatViewStmt" => {
                     self.format_create_table_as_stmt(child)
                 }
+                "CreatePropGraphStmt" => self.format_create_prop_graph_stmt(child),
+                "AlterPropGraphStmt" => self.format_alter_prop_graph_stmt(child),
                 _ => {
                     let text = self.text(child);
                     normalize_whitespace(text)
@@ -236,10 +238,7 @@ impl<'a> Formatter<'a> {
     // ── UPDATE ──────────────────────────────────────────────────────────
 
     pub(crate) fn format_update_stmt(&self, node: Node<'a>) -> String {
-        let table = node
-            .find_child("relation_expr_opt_alias")
-            .map(|n| self.format_relation_expr_opt_alias(n))
-            .unwrap_or_default();
+        let table = self.format_update_delete_target(node);
 
         let mut lines = Vec::new();
 
@@ -418,10 +417,7 @@ impl<'a> Formatter<'a> {
     // ── DELETE ──────────────────────────────────────────────────────────
 
     pub(crate) fn format_delete_stmt(&self, node: Node<'a>) -> String {
-        let table = node
-            .find_child("relation_expr_opt_alias")
-            .map(|n| self.format_relation_expr_opt_alias(n))
-            .unwrap_or_default();
+        let table = self.format_update_delete_target(node);
 
         let mut lines = Vec::new();
 
@@ -1436,6 +1432,66 @@ impl<'a> Formatter<'a> {
 
     // ── Helpers ─────────────────────────────────────────────────────────
 
+    /// Format the target table of an UPDATE/DELETE. Handles both the normal
+    /// `relation_expr_opt_alias` and the PG19 temporal `FOR PORTION OF` variant
+    /// (`relation_expr` + `for_portion_of_clause` [+ alias]).
+    fn format_update_delete_target(&self, node: Node<'a>) -> String {
+        if let Some(rel) = node.find_child("relation_expr_opt_alias") {
+            return self.format_relation_expr_opt_alias(rel);
+        }
+        let mut parts = Vec::new();
+        if let Some(rel) = node.find_child("relation_expr") {
+            parts.push(self.format_relation_expr(rel));
+        }
+        if let Some(fp) = node.find_child("for_portion_of_clause") {
+            parts.push(self.format_for_portion_of_clause(fp));
+        }
+        if let Some(alias) = node.find_child("for_portion_of_opt_alias") {
+            parts.push(self.format_for_portion_of_opt_alias(alias));
+        }
+        parts.join(" ")
+    }
+
+    /// Format a `FOR PORTION OF <column> {FROM <a> TO <b> | (<a>)}` clause (PG19).
+    fn format_for_portion_of_clause(&self, node: Node<'a>) -> String {
+        let col = node
+            .find_child("ColId")
+            .map(|n| self.format_expr(n))
+            .unwrap_or_default();
+        let mut cursor = node.walk();
+        let exprs: Vec<String> = node
+            .named_children(&mut cursor)
+            .filter(|c| c.kind() == "a_expr")
+            .map(|c| self.format_expr(c))
+            .collect();
+        let head = format!(
+            "{} {} {} {col}",
+            self.kw("FOR"),
+            self.kw("PORTION"),
+            self.kw("OF")
+        );
+        if node.has_child("kw_from") {
+            format!(
+                "{head} {} {} {} {}",
+                self.kw("FROM"),
+                exprs.first().cloned().unwrap_or_default(),
+                self.kw("TO"),
+                exprs.get(1).cloned().unwrap_or_default()
+            )
+        } else {
+            format!("{head} ({})", exprs.first().cloned().unwrap_or_default())
+        }
+    }
+
+    /// Format the optional alias following a `FOR PORTION OF` clause.
+    fn format_for_portion_of_opt_alias(&self, node: Node<'a>) -> String {
+        if let Some(colid) = node.find_child("ColId") {
+            format!("{} {}", self.kw("AS"), self.format_expr(colid))
+        } else {
+            self.text(node).to_string()
+        }
+    }
+
     fn format_relation_expr_opt_alias(&self, node: Node<'a>) -> String {
         let mut parts = Vec::new();
         let mut cursor = node.walk();
@@ -1600,7 +1656,7 @@ fn reindent_body(s: &str, indent: &str) -> String {
 /// Collapse runs of whitespace to single spaces, but preserve whitespace
 /// inside single-quoted strings, double-quoted identifiers, and dollar-quoted
 /// strings so that literal content is not altered.
-fn normalize_whitespace(s: &str) -> String {
+pub(crate) fn normalize_whitespace(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let chars: Vec<char> = s.chars().collect();
     let len = chars.len();

--- a/tests/fixtures/pg_dump/generate.sh
+++ b/tests/fixtures/pg_dump/generate.sh
@@ -3,135 +3,47 @@
 # Regenerate the Style::PgDump idempotency fixtures from genuine PostgreSQL
 # deparser output.
 #
-# Stands up a throwaway local cluster (nothing global is touched), creates a
-# set of representative objects, captures pg_get_viewdef / pg_get_functiondef
-# output into this directory, then tears the cluster down. The captured files
-# are committed so the test suite needs no PostgreSQL to run.
+# Stands up a throwaway PostgreSQL container (compose.yaml, nothing global is
+# touched), which loads schema.sql on boot to create a set of representative
+# objects. Captures pg_get_viewdef / pg_get_functiondef output into this
+# directory, then tears the container down. The captured files are committed so
+# the test suite needs no PostgreSQL to run.
 #
-# Requires PostgreSQL client+server binaries on PATH (initdb, pg_ctl, psql).
-# Usage: bash tests/fixtures/pg_dump/generate.sh
+# Requires Docker with the compose plugin. Run from anywhere:
+#   bash tests/fixtures/pg_dump/generate.sh   (or: just gen-pgdump-fixtures)
 set -euo pipefail
 
 FIXDIR="$(cd "$(dirname "$0")" && pwd)"
-PORT=5599
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/pgdump_fix.XXXXXX")"
-export PGDATA="$WORK/data"
-SOCK="$WORK/sock"
-mkdir -p "$SOCK"
+ROOT="$(cd "$FIXDIR/../../.." && pwd)"
+
+compose() { docker compose -f "$ROOT/compose.yaml" "$@"; }
 
 cleanup() {
-    pg_ctl -D "$PGDATA" -w stop >/dev/null 2>&1 || true
-    rm -rf "$WORK"
+    compose down -v >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-echo "initdb ($WORK) ..."
-initdb -D "$PGDATA" --no-locale -E UTF8 -U postgres >/dev/null
-pg_ctl -D "$PGDATA" -o "-k $SOCK -p $PORT -h ''" -l "$WORK/log" -w start >/dev/null
+echo "starting postgres container ..."
+compose up -d --wait
 
-psql() { command psql -h "$SOCK" -p "$PORT" -U postgres -d postgres "$@"; }
-cap() { psql -At -c "$1"; }
-
-echo "creating objects ..."
-psql -v ON_ERROR_STOP=1 -q >/dev/null <<'SQL'
-CREATE SCHEMA app;
-CREATE TABLE app.users (id bigint PRIMARY KEY, email text NOT NULL, country text, created_at timestamptz, active boolean DEFAULT true);
-CREATE TABLE app.orders (id bigint PRIMARY KEY, user_id bigint, total numeric(10,2), placed_at timestamptz);
-
-CREATE VIEW app.us_users AS
-  SELECT id, email, created_at AT TIME ZONE 'UTC' AS created_utc
-  FROM app.users WHERE country = 'US' AND active;
-
-CREATE VIEW app.order_totals AS
-  SELECT u.email, count(*) AS n, sum(o.total) AS revenue
-  FROM app.users u JOIN app.orders o ON o.user_id = u.id
-  WHERE o.placed_at > now() - interval '30 days'
-  GROUP BY u.email HAVING sum(o.total) > 100 ORDER BY revenue DESC;
-
-CREATE VIEW app.win AS
-  SELECT email, row_number() OVER (PARTITION BY country ORDER BY created_at) AS rn FROM app.users;
-
-CREATE VIEW app.uni AS
-  SELECT id FROM app.users UNION SELECT user_id FROM app.orders;
-
--- Nested shapes: CTEs, CASE blocks, comma-separated FROM.
-CREATE VIEW app.recent_cte AS
-  WITH recent AS (SELECT user_id, total FROM app.orders WHERE placed_at > now() - interval '7 days')
-  SELECT user_id, sum(total) AS wk FROM recent GROUP BY user_id;
-CREATE VIEW app.two_cte AS
-  WITH x AS (SELECT id AS a FROM app.users), y AS (SELECT id AS b FROM app.orders)
-  SELECT x.a, y.b FROM x, y;
-CREATE VIEW app.distinct_case AS
-  SELECT DISTINCT country, CASE WHEN active THEN 'on' ELSE 'off' END AS st FROM app.users;
-CREATE VIEW app.case_plain AS
-  SELECT id, CASE WHEN active THEN 'on' ELSE 'off' END AS st FROM app.users;
-CREATE VIEW app.case_first AS
-  SELECT CASE WHEN active THEN 1 ELSE 0 END AS x, id FROM app.users;
-
--- Subqueries embedded in expressions (IN, EXISTS, scalar in target list).
-CREATE VIEW app.sub AS
-  SELECT u.email FROM app.users u WHERE u.id IN (SELECT user_id FROM app.orders);
-CREATE VIEW app.sub_exists AS
-  SELECT u.email FROM app.users u
-  WHERE EXISTS (SELECT 1 FROM app.orders o WHERE o.user_id = u.id);
-CREATE VIEW app.sub_scalar AS
-  SELECT u.email, (SELECT count(*) FROM app.orders o WHERE o.user_id = u.id) AS n FROM app.users u;
-
--- LIMIT / OFFSET, derived tables in FROM, set-op with trailing ORDER BY/LIMIT.
-CREATE VIEW app.lim AS
-  SELECT id FROM app.users ORDER BY id LIMIT 10 OFFSET 5;
-CREATE VIEW app.derived AS
-  SELECT s.email FROM (SELECT email FROM app.users WHERE active) s;
-CREATE VIEW app.derived_join AS
-  SELECT u.email, t.n FROM app.users u
-  JOIN (SELECT user_id, count(*) AS n FROM app.orders GROUP BY user_id) t ON t.user_id = u.id;
-CREATE VIEW app.union_order AS
-  SELECT id FROM app.users UNION SELECT user_id FROM app.orders ORDER BY 1 LIMIT 3;
-
--- Deeper / varied real-world shapes (validation sweep).
-CREATE VIEW app.nested_sub AS
-  SELECT id, email FROM app.users u1
-  WHERE EXISTS (SELECT 1 FROM app.orders o
-                WHERE o.user_id = u1.id AND o.total > (SELECT avg(total) FROM app.orders));
-CREATE VIEW app.lateral AS
-  SELECT t.uid, t.s FROM app.users u,
-  LATERAL (SELECT u.id AS uid, sum(total) AS s FROM app.orders o WHERE o.user_id = u.id GROUP BY u.id) t;
-CREATE VIEW app.window_frame AS
-  SELECT id, sum(total) OVER (PARTITION BY user_id ORDER BY placed_at
-    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS run FROM app.orders;
-CREATE VIEW app.distinct_on AS
-  SELECT DISTINCT ON (country) country, id FROM app.users ORDER BY country, id;
-CREATE VIEW app.filter_agg AS
-  SELECT count(*) FILTER (WHERE active) AS act, count(*) AS cnt FROM app.users;
-
-CREATE FUNCTION app.add(a integer, b integer) RETURNS integer LANGUAGE sql IMMUTABLE AS $$ SELECT a + b $$;
-CREATE FUNCTION app.bump(p_id bigint) RETURNS void LANGUAGE plpgsql AS $fn$
-BEGIN
-  UPDATE app.users SET active = true WHERE id = p_id;
-END;
-$fn$;
--- Function variety: DEFAULT args, OUT params, VARIADIC, RETURNS TABLE/SETOF,
--- grouped behavior attributes, SET, SQL-standard RETURN body.
-CREATE FUNCTION app.fn_default(a integer, b integer DEFAULT 0) RETURNS integer LANGUAGE sql AS $$ SELECT a + b $$;
-CREATE FUNCTION app.fn_out(IN a integer, OUT q integer, OUT r integer) LANGUAGE sql AS $$ SELECT a / 2, a % 2 $$;
-CREATE FUNCTION app.fn_variadic(VARIADIC arr integer[]) RETURNS integer LANGUAGE sql AS $$ SELECT array_length(arr, 1) $$;
-CREATE FUNCTION app.fn_table(x integer) RETURNS TABLE(a integer, b text) LANGUAGE sql AS $$ SELECT x, 'y'::text $$;
-CREATE FUNCTION app.fn_setof(x integer) RETURNS SETOF integer LANGUAGE sql AS $$ SELECT generate_series(1, x) $$;
-CREATE FUNCTION app.fn_behavior(x integer) RETURNS integer LANGUAGE sql STRICT IMMUTABLE PARALLEL SAFE AS $$ SELECT x $$;
-CREATE FUNCTION app.fn_set(x integer) RETURNS integer LANGUAGE sql SET search_path TO 'public' AS $$ SELECT x $$;
-CREATE FUNCTION app.fn_return(x integer) RETURNS integer LANGUAGE sql RETURN x + 1;
-SQL
+cap() { compose exec -T postgres psql -At -U postgres -d postgres -c "$1"; }
 
 echo "capturing fixtures ..."
 for v in us_users order_totals win uni recent_cte two_cte distinct_case case_plain case_first \
          sub sub_exists sub_scalar lim derived derived_join union_order \
-         nested_sub lateral window_frame distinct_on filter_agg; do
+         nested_sub lateral window_frame distinct_on filter_agg \
+         nulls_win within_group; do
     cap "SELECT pg_get_viewdef('app.$v'::regclass, true);" > "$FIXDIR/view_$v.sql"
 done
 cap "SELECT pg_get_functiondef('app.add(integer,integer)'::regprocedure);" > "$FIXDIR/func_add.sql"
 cap "SELECT pg_get_functiondef('app.bump(bigint)'::regprocedure);" > "$FIXDIR/func_bump.sql"
 for f in fn_default fn_out fn_variadic fn_table fn_setof fn_behavior fn_set fn_return; do
     cap "SELECT pg_get_functiondef(p.oid) FROM pg_proc p WHERE p.proname = '$f';" > "$FIXDIR/func_${f#fn_}.sql"
+done
+# PostgreSQL 19 SQL/PGQ property graphs. pg_dump terminates the deparser body
+# with a semicolon, so the fixture carries one to match what a dump emits.
+for g in graph_min graph_shop; do
+    cap "SELECT pg_get_propgraphdef('app.$g'::regclass) || ';';" > "$FIXDIR/propgraph_${g#graph_}.sql"
 done
 
 echo "done — fixtures written to $FIXDIR"

--- a/tests/fixtures/pg_dump/propgraph_min.sql
+++ b/tests/fixtures/pg_dump/propgraph_min.sql
@@ -1,0 +1,4 @@
+CREATE PROPERTY GRAPH app.graph_min
+    VERTEX TABLES (
+        app.users KEY (id) PROPERTIES (active, country, created_at, email, id)
+    );

--- a/tests/fixtures/pg_dump/propgraph_shop.sql
+++ b/tests/fixtures/pg_dump/propgraph_shop.sql
@@ -1,0 +1,8 @@
+CREATE PROPERTY GRAPH app.graph_shop
+    VERTEX TABLES (
+        app.orders KEY (id) LABEL purchase PROPERTIES (id, placed_at, total, user_id),
+        app.users KEY (id) LABEL customer PROPERTIES (active, country, created_at, email, id)
+    )
+    EDGE TABLES (
+        app.orders AS made KEY (id) SOURCE KEY (user_id) REFERENCES users (id) DESTINATION KEY (id) REFERENCES orders (id) LABEL placed PROPERTIES (id, placed_at, total, user_id)
+    );

--- a/tests/fixtures/pg_dump/schema.sql
+++ b/tests/fixtures/pg_dump/schema.sql
@@ -1,0 +1,122 @@
+-- Scaffolding schema for the Style::PgDump idempotency round-trip.
+--
+-- Loaded two ways, both producing the same objects:
+--   * as a Postgres init script (mounted into /docker-entrypoint-initdb.d by
+--     compose.yaml), and
+--   * by generate.sh, which then captures pg_get_viewdef / pg_get_functiondef
+--     output into the view_*.sql / func_*.sql fixtures beside this file.
+--
+-- The captured deparser output is the actual test input; this file only exists
+-- to produce it. Keep the object set representative of real-world SQL shapes.
+
+CREATE SCHEMA app;
+CREATE TABLE app.users (id bigint PRIMARY KEY, email text NOT NULL, country text, created_at timestamptz, active boolean DEFAULT true);
+CREATE TABLE app.orders (id bigint PRIMARY KEY, user_id bigint, total numeric(10,2), placed_at timestamptz);
+
+CREATE VIEW app.us_users AS
+  SELECT id, email, created_at AT TIME ZONE 'UTC' AS created_utc
+  FROM app.users WHERE country = 'US' AND active;
+
+CREATE VIEW app.order_totals AS
+  SELECT u.email, count(*) AS n, sum(o.total) AS revenue
+  FROM app.users u JOIN app.orders o ON o.user_id = u.id
+  WHERE o.placed_at > now() - interval '30 days'
+  GROUP BY u.email HAVING sum(o.total) > 100 ORDER BY revenue DESC;
+
+CREATE VIEW app.win AS
+  SELECT email, row_number() OVER (PARTITION BY country ORDER BY created_at) AS rn FROM app.users;
+
+CREATE VIEW app.uni AS
+  SELECT id FROM app.users UNION SELECT user_id FROM app.orders;
+
+-- Nested shapes: CTEs, CASE blocks, comma-separated FROM.
+CREATE VIEW app.recent_cte AS
+  WITH recent AS (SELECT user_id, total FROM app.orders WHERE placed_at > now() - interval '7 days')
+  SELECT user_id, sum(total) AS wk FROM recent GROUP BY user_id;
+CREATE VIEW app.two_cte AS
+  WITH x AS (SELECT id AS a FROM app.users), y AS (SELECT id AS b FROM app.orders)
+  SELECT x.a, y.b FROM x, y;
+CREATE VIEW app.distinct_case AS
+  SELECT DISTINCT country, CASE WHEN active THEN 'on' ELSE 'off' END AS st FROM app.users;
+CREATE VIEW app.case_plain AS
+  SELECT id, CASE WHEN active THEN 'on' ELSE 'off' END AS st FROM app.users;
+CREATE VIEW app.case_first AS
+  SELECT CASE WHEN active THEN 1 ELSE 0 END AS x, id FROM app.users;
+
+-- Subqueries embedded in expressions (IN, EXISTS, scalar in target list).
+CREATE VIEW app.sub AS
+  SELECT u.email FROM app.users u WHERE u.id IN (SELECT user_id FROM app.orders);
+CREATE VIEW app.sub_exists AS
+  SELECT u.email FROM app.users u
+  WHERE EXISTS (SELECT 1 FROM app.orders o WHERE o.user_id = u.id);
+CREATE VIEW app.sub_scalar AS
+  SELECT u.email, (SELECT count(*) FROM app.orders o WHERE o.user_id = u.id) AS n FROM app.users u;
+
+-- LIMIT / OFFSET, derived tables in FROM, set-op with trailing ORDER BY/LIMIT.
+CREATE VIEW app.lim AS
+  SELECT id FROM app.users ORDER BY id LIMIT 10 OFFSET 5;
+CREATE VIEW app.derived AS
+  SELECT s.email FROM (SELECT email FROM app.users WHERE active) s;
+CREATE VIEW app.derived_join AS
+  SELECT u.email, t.n FROM app.users u
+  JOIN (SELECT user_id, count(*) AS n FROM app.orders GROUP BY user_id) t ON t.user_id = u.id;
+CREATE VIEW app.union_order AS
+  SELECT id FROM app.users UNION SELECT user_id FROM app.orders ORDER BY 1 LIMIT 3;
+
+-- Deeper / varied real-world shapes (validation sweep).
+CREATE VIEW app.nested_sub AS
+  SELECT id, email FROM app.users u1
+  WHERE EXISTS (SELECT 1 FROM app.orders o
+                WHERE o.user_id = u1.id AND o.total > (SELECT avg(total) FROM app.orders));
+CREATE VIEW app.lateral AS
+  SELECT t.uid, t.s FROM app.users u,
+  LATERAL (SELECT u.id AS uid, sum(total) AS s FROM app.orders o WHERE o.user_id = u.id GROUP BY u.id) t;
+CREATE VIEW app.window_frame AS
+  SELECT id, sum(total) OVER (PARTITION BY user_id ORDER BY placed_at
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS run FROM app.orders;
+CREATE VIEW app.distinct_on AS
+  SELECT DISTINCT ON (country) country, id FROM app.users ORDER BY country, id;
+CREATE VIEW app.filter_agg AS
+  SELECT count(*) FILTER (WHERE active) AS act, count(*) AS cnt FROM app.users;
+
+CREATE FUNCTION app.add(a integer, b integer) RETURNS integer LANGUAGE sql IMMUTABLE AS $$ SELECT a + b $$;
+CREATE FUNCTION app.bump(p_id bigint) RETURNS void LANGUAGE plpgsql AS $fn$
+BEGIN
+  UPDATE app.users SET active = true WHERE id = p_id;
+END;
+$fn$;
+-- Function variety: DEFAULT args, OUT params, VARIADIC, RETURNS TABLE/SETOF,
+-- grouped behavior attributes, SET, SQL-standard RETURN body.
+CREATE FUNCTION app.fn_default(a integer, b integer DEFAULT 0) RETURNS integer LANGUAGE sql AS $$ SELECT a + b $$;
+CREATE FUNCTION app.fn_out(IN a integer, OUT q integer, OUT r integer) LANGUAGE sql AS $$ SELECT a / 2, a % 2 $$;
+CREATE FUNCTION app.fn_variadic(VARIADIC arr integer[]) RETURNS integer LANGUAGE sql AS $$ SELECT array_length(arr, 1) $$;
+CREATE FUNCTION app.fn_table(x integer) RETURNS TABLE(a integer, b text) LANGUAGE sql AS $$ SELECT x, 'y'::text $$;
+CREATE FUNCTION app.fn_setof(x integer) RETURNS SETOF integer LANGUAGE sql AS $$ SELECT generate_series(1, x) $$;
+CREATE FUNCTION app.fn_behavior(x integer) RETURNS integer LANGUAGE sql STRICT IMMUTABLE PARALLEL SAFE AS $$ SELECT x $$;
+CREATE FUNCTION app.fn_set(x integer) RETURNS integer LANGUAGE sql SET search_path TO 'public' AS $$ SELECT x $$;
+CREATE FUNCTION app.fn_return(x integer) RETURNS integer LANGUAGE sql RETURN x + 1;
+
+-- PostgreSQL 19 features.
+--
+-- SQL/PGQ property graphs (pg_get_propgraphdef): a vertex-only graph and a
+-- full graph with labels, an aliased edge, and SOURCE/DESTINATION references.
+CREATE PROPERTY GRAPH app.graph_min
+  VERTEX TABLES (app.users);
+CREATE PROPERTY GRAPH app.graph_shop
+  VERTEX TABLES (
+    app.users KEY (id) LABEL customer,
+    app.orders KEY (id) LABEL purchase
+  )
+  EDGE TABLES (
+    app.orders AS made KEY (id)
+      SOURCE KEY (user_id) REFERENCES users (id)
+      DESTINATION KEY (id) REFERENCES orders (id)
+      LABEL placed
+  );
+
+-- Window null treatment (IGNORE NULLS) and ordered-set aggregate (WITHIN GROUP)
+-- captured via a view, exercising the aggregate-clause formatting path.
+CREATE VIEW app.nulls_win AS
+  SELECT id, lag(email) IGNORE NULLS OVER (ORDER BY id) AS prev_email FROM app.users;
+CREATE VIEW app.within_group AS
+  SELECT country, percentile_cont(0.5) WITHIN GROUP (ORDER BY id) AS med FROM app.users GROUP BY country;

--- a/tests/fixtures/pg_dump/view_nulls_win.sql
+++ b/tests/fixtures/pg_dump/view_nulls_win.sql
@@ -1,0 +1,3 @@
+ SELECT id,
+    lag(email) IGNORE NULLS OVER (ORDER BY id) AS prev_email
+   FROM app.users;

--- a/tests/fixtures/pg_dump/view_within_group.sql
+++ b/tests/fixtures/pg_dump/view_within_group.sql
@@ -1,0 +1,4 @@
+ SELECT country,
+    percentile_cont(0.5::double precision) WITHIN GROUP (ORDER BY (id::double precision)) AS med
+   FROM app.users
+  GROUP BY country;

--- a/tests/pgdump_idempotency_test.rs
+++ b/tests/pgdump_idempotency_test.rs
@@ -22,6 +22,9 @@ fn pgdump_fixtures_are_idempotent() {
         .filter_map(Result::ok)
         .map(|e| e.path())
         .filter(|p| p.extension().is_some_and(|e| e == "sql"))
+        // schema.sql is the input scaffolding that produces these fixtures, not
+        // deparser output — it is not expected to be idempotent.
+        .filter(|p| p.file_name().is_some_and(|n| n != "schema.sql"))
         .collect();
     entries.sort();
 

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -123,6 +123,489 @@ fn broken_statement_errors_instead_of_dropping() {
     );
 }
 
+// PG19: RESPECT/IGNORE NULLS null-treatment on window functions must be
+// preserved rather than silently dropped.
+#[test]
+fn window_null_treatment_river() {
+    let cases = [
+        (
+            "SELECT first_value(price) respect nulls over (order by ts) FROM t",
+            "SELECT FIRST_VALUE(price) RESPECT NULLS OVER (ORDER BY ts)\n  FROM t;",
+        ),
+        (
+            "SELECT lag(price) ignore nulls over (order by ts) FROM t",
+            "SELECT LAG(price) IGNORE NULLS OVER (ORDER BY ts)\n  FROM t;",
+        ),
+    ];
+    for (sql, expected) in cases {
+        let result = format(sql, Style::River).unwrap();
+        assert_eq!(result, expected, "\nInput: {sql}\nGot:\n{result}");
+    }
+}
+
+// PG19: UPDATE/DELETE ... FOR PORTION OF (temporal tables). Both the table
+// name and the clause must be preserved.
+#[test]
+fn for_portion_of_river() {
+    let update = format(
+        "UPDATE employees FOR PORTION OF valid_period FROM '2020-01-01' TO '2021-01-01' SET salary = salary * 1.1 WHERE id = 5",
+        Style::River,
+    )
+    .unwrap();
+    assert_eq!(
+        update,
+        "\
+UPDATE employees FOR PORTION OF valid_period FROM '2020-01-01' TO '2021-01-01'
+   SET salary = salary * 1.1
+ WHERE id = 5;",
+        "\nGot:\n{update}"
+    );
+
+    let delete = format(
+        "DELETE FROM employees FOR PORTION OF valid_period FROM '2020-01-01' TO '2021-01-01' WHERE id = 5",
+        Style::River,
+    )
+    .unwrap();
+    assert_eq!(
+        delete,
+        "\
+DELETE
+  FROM employees FOR PORTION OF valid_period FROM '2020-01-01' TO '2021-01-01'
+ WHERE id = 5;",
+        "\nGot:\n{delete}"
+    );
+}
+
+// Aggregate FILTER (WHERE ...) must be preserved and keyword-cased.
+#[test]
+fn aggregate_filter_clause() {
+    let sql = "SELECT count(*) filter (where active) FROM users";
+    assert_eq!(
+        format(sql, Style::River).unwrap(),
+        "SELECT COUNT(*) FILTER (WHERE active)\n  FROM users;"
+    );
+    // Left-aligned, lowercase-keyword style.
+    assert_eq!(
+        format(sql, Style::Dbt).unwrap(),
+        "select count(*) filter (where active)\n\nfrom users;"
+    );
+}
+
+// Ordered-set aggregate WITHIN GROUP (ORDER BY ...) must be preserved.
+#[test]
+fn aggregate_within_group_clause() {
+    let sql = "SELECT percentile_cont(0.5) within group (order by score desc) FROM t";
+    assert_eq!(
+        format(sql, Style::River).unwrap(),
+        "SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY score DESC)\n  FROM t;"
+    );
+    // Leading-comma, lowercase-keyword style.
+    assert_eq!(
+        format(sql, Style::Mattmc3).unwrap(),
+        "select percentile_cont(0.5) within group (order by score desc)\n  from t;"
+    );
+}
+
+// WITHIN GROUP, FILTER, and OVER can co-occur and must render in grammar order.
+#[test]
+fn aggregate_within_group_filter_over() {
+    let sql =
+        "SELECT rank() within group (order by a) filter (where b) over (partition by c) FROM t";
+    assert_eq!(
+        format(sql, Style::River).unwrap(),
+        "SELECT RANK() WITHIN GROUP (ORDER BY a) FILTER (WHERE b) OVER (PARTITION BY c)\n  FROM t;"
+    );
+}
+
+// PG19: GRAPH_TABLE (SQL/PGQ) lays out as an indented block — graph name,
+// MATCH and COLUMNS each on their own line; vertices/edges glue without
+// separators while their inner contents are space-separated. River-family
+// styles anchor the block continuation lines to the FROM content column;
+// left-aligned styles indent at their own width with the paren de-dented to
+// column 0; pg_dump keeps the query verbatim on one line.
+#[test]
+fn graph_table_all_styles() {
+    let sql = "SELECT * FROM graph_table (my_graph match (a)-[e]->(b) columns (a.id, b.id))";
+    let river = "\
+SELECT *
+  FROM GRAPH_TABLE (
+           my_graph
+           MATCH (a)-[e]->(b)
+           COLUMNS (a.id, b.id)
+       );";
+    let cases = [
+        (Style::River, river),
+        (Style::Aweber, river),
+        (
+            Style::Mattmc3,
+            "\
+select *
+  from graph_table (
+           my_graph
+           match (a)-[e]->(b)
+           columns (a.id, b.id)
+       );",
+        ),
+        (
+            Style::Dbt,
+            "\
+select *
+
+from graph_table (
+    my_graph
+    match (a)-[e]->(b)
+    columns (a.id, b.id)
+);",
+        ),
+        (
+            Style::Mozilla,
+            "\
+SELECT *
+FROM GRAPH_TABLE (
+    my_graph
+    MATCH (a)-[e]->(b)
+    COLUMNS (a.id, b.id)
+);",
+        ),
+        (
+            Style::Gitlab,
+            "\
+SELECT *
+FROM GRAPH_TABLE (
+  my_graph
+  MATCH (a)-[e]->(b)
+  COLUMNS (a.id, b.id)
+);",
+        ),
+        (
+            Style::Kickstarter,
+            "\
+SELECT *
+FROM GRAPH_TABLE (
+  my_graph
+  MATCH (a)-[e]->(b)
+  COLUMNS (a.id, b.id)
+);",
+        ),
+        (
+            Style::PgDump,
+            " SELECT *\n   FROM graph_table (my_graph match (a)-[e]->(b) columns (a.id, b.id));",
+        ),
+    ];
+    for (style, expected) in cases {
+        let got = format(sql, style).unwrap();
+        assert_eq!(got, expected, "\nstyle: {style:?}\ngot:\n{got}");
+    }
+}
+
+// GRAPH_TABLE with element labels, inline element WHERE filters, a top-level
+// pattern WHERE, aliased output columns, and a table alias.
+#[test]
+fn graph_table_complex() {
+    let sql = "SELECT an, bn FROM graph_table (g match (a is person where a.age>20)-[e is knows]->(b) where a.id<>b.id columns (a.name as an, b.name as bn)) as t WHERE an IS NOT NULL";
+    assert_eq!(
+        format(sql, Style::River).unwrap(),
+        "\
+SELECT an,
+       bn
+  FROM GRAPH_TABLE (
+           g
+           MATCH (a IS person WHERE a.age > 20)-[e IS knows]->(b) WHERE a.id <> b.id
+           COLUMNS (a.name AS an, b.name AS bn)
+       ) AS t
+ WHERE an IS NOT NULL;"
+    );
+}
+
+// GRAPH_TABLE label alternation (`IS A|B`) and a path quantifier (`{2}`).
+#[test]
+fn graph_table_label_disjunction_and_quantifier() {
+    let sql = "SELECT * FROM graph_table (g match (a is person|employee){2} columns (a.id))";
+    assert_eq!(
+        format(sql, Style::River).unwrap(),
+        "\
+SELECT *
+  FROM GRAPH_TABLE (
+           g
+           MATCH (a IS person | employee){2}
+           COLUMNS (a.id)
+       );"
+    );
+}
+
+// GRAPH_TABLE as the left side of a JOIN still aligns its block, and remains
+// idempotent when re-formatted.
+#[test]
+fn graph_table_joined_and_idempotent() {
+    let sql = "SELECT * FROM graph_table (g match (a)-[e]->(b) columns (a.id)) t JOIN other o ON o.id = t.id";
+    let expected = "\
+SELECT *
+  FROM GRAPH_TABLE (
+           g
+           MATCH (a)-[e]->(b)
+           COLUMNS (a.id)
+       ) AS t
+  JOIN other AS o
+    ON o.id = t.id;";
+    assert_eq!(format(sql, Style::River).unwrap(), expected);
+    assert_eq!(
+        format(expected, Style::River).unwrap(),
+        expected,
+        "\nnot idempotent"
+    );
+}
+
+// PG19: CREATE PROPERTY GRAPH. River-family styles (river/aweber/mattmc3)
+// align each element's fields into columns, using the same pad-to-max +
+// single-space semantics as CREATE TABLE's column/type alignment.
+#[test]
+fn create_property_graph_river_aligned() {
+    let sql = "CREATE PROPERTY GRAPH myshop VERTEX TABLES ( products LABEL product, customers LABEL customer, orders LABEL \"order\" ) EDGE TABLES ( order_items SOURCE orders DESTINATION products LABEL contains, customer_orders SOURCE customers DESTINATION orders LABEL has_placed )";
+    let expected = "\
+CREATE PROPERTY GRAPH myshop
+    VERTEX TABLES (
+        products  LABEL product,
+        customers LABEL customer,
+        orders    LABEL \"order\"
+    )
+    EDGE TABLES (
+        order_items     SOURCE orders    DESTINATION products LABEL contains,
+        customer_orders SOURCE customers DESTINATION orders   LABEL has_placed
+    );";
+    assert_eq!(format(sql, Style::Aweber).unwrap(), expected, "\naweber");
+    assert_eq!(format(sql, Style::River).unwrap(), expected, "\nriver");
+    // mattmc3 shares the alignment but lowercases keywords.
+    assert_eq!(
+        format(sql, Style::Mattmc3).unwrap(),
+        "\
+create property graph myshop
+    vertex tables (
+        products  label product,
+        customers label customer,
+        orders    label \"order\"
+    )
+    edge tables (
+        order_items     source orders    destination products label contains,
+        customer_orders source customers destination orders   label has_placed
+    );",
+        "\nmattmc3"
+    );
+}
+
+// PG19: the pg_dump renderer reproduces pg_get_propgraphdef's layout — each
+// vertex/edge element on one line — terminated with a semicolon as pg_dump
+// emits it. See the byte-for-byte fixtures in tests/fixtures/pg_dump/propgraph_*.sql.
+#[test]
+fn create_property_graph_pg_dump() {
+    let sql = "CREATE PROPERTY GRAPH myshop VERTEX TABLES ( products KEY (product_no), customers KEY (customer_id), orders KEY (order_id) ) EDGE TABLES ( order_items KEY (order_items_id) SOURCE KEY (order_id) REFERENCES orders (order_id) DESTINATION KEY (product_no) REFERENCES products (product_no), customer_orders KEY (customer_orders_id) SOURCE KEY (customer_id) REFERENCES customers (customer_id) DESTINATION KEY (order_id) REFERENCES orders (order_id) )";
+    let expected = "\
+CREATE PROPERTY GRAPH myshop
+    VERTEX TABLES (
+        products KEY (product_no),
+        customers KEY (customer_id),
+        orders KEY (order_id)
+    )
+    EDGE TABLES (
+        order_items KEY (order_items_id) SOURCE KEY (order_id) REFERENCES orders (order_id) DESTINATION KEY (product_no) REFERENCES products (product_no),
+        customer_orders KEY (customer_orders_id) SOURCE KEY (customer_id) REFERENCES customers (customer_id) DESTINATION KEY (order_id) REFERENCES orders (order_id)
+    );";
+    assert_eq!(format(sql, Style::PgDump).unwrap(), expected);
+    // Idempotent: feeding the layout back through reproduces it.
+    assert_eq!(
+        format(expected, Style::PgDump).unwrap(),
+        expected,
+        "\nnot idempotent"
+    );
+}
+
+// Non-river left-aligned styles (dbt/mozilla/gitlab/kickstarter) render one
+// element per line without column alignment, honoring their case and indent
+// (4-space for dbt/mozilla, 2-space for gitlab/kickstarter). Also exercises
+// NODE/RELATIONSHIP synonyms, AS aliases, PROPERTIES lists, NO PROPERTIES, and
+// PROPERTIES ALL COLUMNS.
+#[test]
+fn create_property_graph_left_aligned() {
+    let sql = "CREATE PROPERTY GRAPH g NODE TABLES ( persons AS p KEY (id) LABEL person PROPERTIES (p.name, p.age AS years), accounts KEY (acct_id) LABEL account NO PROPERTIES ) RELATIONSHIP TABLES ( owns SOURCE KEY (person_id) REFERENCES persons (id) DESTINATION KEY (acct_id) REFERENCES accounts (acct_id) LABEL owns PROPERTIES ALL COLUMNS )";
+    let cases = [
+        (
+            Style::Dbt,
+            "\
+create property graph g
+    node tables (
+        persons as p key (id) label person properties (p.name, p.age as years),
+        accounts key (acct_id) label account no properties
+    )
+    relationship tables (
+        owns source key (person_id) references persons (id) destination key (acct_id) references accounts (acct_id) label owns properties all columns
+    );",
+        ),
+        (
+            Style::Mozilla,
+            "\
+CREATE PROPERTY GRAPH g
+    NODE TABLES (
+        persons AS p KEY (id) LABEL person PROPERTIES (p.name, p.age AS years),
+        accounts KEY (acct_id) LABEL account NO PROPERTIES
+    )
+    RELATIONSHIP TABLES (
+        owns SOURCE KEY (person_id) REFERENCES persons (id) DESTINATION KEY (acct_id) REFERENCES accounts (acct_id) LABEL owns PROPERTIES ALL COLUMNS
+    );",
+        ),
+        (
+            Style::Gitlab,
+            "\
+CREATE PROPERTY GRAPH g
+  NODE TABLES (
+    persons AS p KEY (id) LABEL person PROPERTIES (p.name, p.age AS years),
+    accounts KEY (acct_id) LABEL account NO PROPERTIES
+  )
+  RELATIONSHIP TABLES (
+    owns SOURCE KEY (person_id) REFERENCES persons (id) DESTINATION KEY (acct_id) REFERENCES accounts (acct_id) LABEL owns PROPERTIES ALL COLUMNS
+  );",
+        ),
+        (
+            Style::Kickstarter,
+            "\
+CREATE PROPERTY GRAPH g
+  NODE TABLES (
+    persons AS p KEY (id) LABEL person PROPERTIES (p.name, p.age AS years),
+    accounts KEY (acct_id) LABEL account NO PROPERTIES
+  )
+  RELATIONSHIP TABLES (
+    owns SOURCE KEY (person_id) REFERENCES persons (id) DESTINATION KEY (acct_id) REFERENCES accounts (acct_id) LABEL owns PROPERTIES ALL COLUMNS
+  );",
+        ),
+    ];
+    for (style, expected) in cases {
+        let got = format(sql, style).unwrap();
+        assert_eq!(got, expected, "\nstyle: {style:?}\ngot:\n{got}");
+    }
+}
+
+// PG19: ALTER PROPERTY GRAPH ... ADD VERTEX/EDGE TABLES reuses the CREATE block
+// layout (each clause prefixed with ADD), across all styles.
+#[test]
+fn alter_property_graph_add_tables() {
+    let sql = "ALTER PROPERTY GRAPH myshop ADD VERTEX TABLES (products KEY (id) LABEL product, customers KEY (cid)) ADD EDGE TABLES (rel SOURCE KEY (a) REFERENCES products (id) DESTINATION KEY (b) REFERENCES customers (cid) LABEL r)";
+    // River-family aligns element fields into columns.
+    let river = "\
+ALTER PROPERTY GRAPH myshop
+    ADD VERTEX TABLES (
+        products  KEY (id)  LABEL product,
+        customers KEY (cid)
+    )
+    ADD EDGE TABLES (
+        rel SOURCE KEY (a) REFERENCES products (id) DESTINATION KEY (b) REFERENCES customers (cid) LABEL r
+    );";
+    let cases = [
+        (Style::River, river),
+        (Style::Aweber, river),
+        (
+            Style::Mattmc3,
+            "\
+alter property graph myshop
+    add vertex tables (
+        products  key (id)  label product,
+        customers key (cid)
+    )
+    add edge tables (
+        rel source key (a) references products (id) destination key (b) references customers (cid) label r
+    );",
+        ),
+        (
+            Style::Dbt,
+            "\
+alter property graph myshop
+    add vertex tables (
+        products key (id) label product,
+        customers key (cid)
+    )
+    add edge tables (
+        rel source key (a) references products (id) destination key (b) references customers (cid) label r
+    );",
+        ),
+        (
+            Style::Mozilla,
+            "\
+ALTER PROPERTY GRAPH myshop
+    ADD VERTEX TABLES (
+        products KEY (id) LABEL product,
+        customers KEY (cid)
+    )
+    ADD EDGE TABLES (
+        rel SOURCE KEY (a) REFERENCES products (id) DESTINATION KEY (b) REFERENCES customers (cid) LABEL r
+    );",
+        ),
+        (
+            Style::Gitlab,
+            "\
+ALTER PROPERTY GRAPH myshop
+  ADD VERTEX TABLES (
+    products KEY (id) LABEL product,
+    customers KEY (cid)
+  )
+  ADD EDGE TABLES (
+    rel SOURCE KEY (a) REFERENCES products (id) DESTINATION KEY (b) REFERENCES customers (cid) LABEL r
+  );",
+        ),
+        (
+            Style::Kickstarter,
+            "\
+ALTER PROPERTY GRAPH myshop
+  ADD VERTEX TABLES (
+    products KEY (id) LABEL product,
+    customers KEY (cid)
+  )
+  ADD EDGE TABLES (
+    rel SOURCE KEY (a) REFERENCES products (id) DESTINATION KEY (b) REFERENCES customers (cid) LABEL r
+  );",
+        ),
+    ];
+    for (style, expected) in cases {
+        let got = format(sql, style).unwrap();
+        assert_eq!(got, expected, "\nstyle: {style:?}\ngot:\n{got}");
+        // Re-formatting the multi-line block reproduces it.
+        assert_eq!(
+            format(expected, style).unwrap(),
+            expected,
+            "\nstyle: {style:?} not idempotent"
+        );
+    }
+    // pg_dump uses the same structured block with a terminating semicolon.
+    assert_eq!(
+        format(sql, Style::PgDump).unwrap(),
+        "\
+ALTER PROPERTY GRAPH myshop
+    ADD VERTEX TABLES (
+        products KEY (id) LABEL product,
+        customers KEY (cid)
+    )
+    ADD EDGE TABLES (
+        rel SOURCE KEY (a) REFERENCES products (id) DESTINATION KEY (b) REFERENCES customers (cid) LABEL r
+    );"
+    );
+}
+
+// The short ALTER PROPERTY GRAPH forms (DROP TABLES, ALTER ... TABLE ... LABEL)
+// have no multi-element block, so they stay on one line, keyword-cased.
+#[test]
+fn alter_property_graph_single_line_forms() {
+    let drop = "ALTER PROPERTY GRAPH myshop DROP VERTEX TABLES (products, customers) CASCADE";
+    assert_eq!(
+        format(drop, Style::River).unwrap(),
+        "ALTER PROPERTY GRAPH myshop DROP VERTEX TABLES (products, customers) CASCADE;"
+    );
+    assert_eq!(
+        format(drop, Style::Dbt).unwrap(),
+        "alter property graph myshop drop vertex tables (products, customers) cascade;"
+    );
+    let label = "ALTER PROPERTY GRAPH g ALTER VERTEX TABLE persons ADD LABEL vip PROPERTIES (tier)";
+    assert_eq!(
+        format(label, Style::River).unwrap(),
+        "ALTER PROPERTY GRAPH g ALTER VERTEX TABLE persons ADD LABEL vip PROPERTIES (tier);"
+    );
+}
+
 #[test]
 fn cast_multiword_type_names() {
     // Regression: multi-word type names in :: casts must not be truncated


### PR DESCRIPTION
## Summary

Adds PostgreSQL 19 support: bumps `tree-sitter-postgres` to `19.0.0-beta.2` and formats the new PG19 syntax across all eight styles, with a Docker-based round-trip harness that validates the `pg_dump` style against genuine deparser output.

## Features

- **SQL/PGQ property graphs**
  - `CREATE PROPERTY GRAPH` — column-aligned for the river family (river/aweber/mattmc3), one element per line for the left-aligned styles (dbt/mozilla/gitlab/kickstarter), and byte-for-byte `pg_get_propgraphdef` for `pg_dump`.
  - `ALTER PROPERTY GRAPH` — `ADD VERTEX/EDGE TABLES` reuses the `CREATE` block layout (each clause prefixed with `ADD`); the short `DROP ... TABLES` and `ALTER ... TABLE ... LABEL` forms stay on one line.
- **`GRAPH_TABLE` queries** — laid out as an indented block (graph name, `MATCH`, `COLUMNS` each on their own line), anchored to the `FROM` content column for river styles.
- **`FOR PORTION OF`** temporal `UPDATE`/`DELETE` preserved.
- **Window null treatment** (`RESPECT`/`IGNORE NULLS`) and **ordered-set `WITHIN GROUP`** — both were previously dropped; now emitted in grammar order alongside `FILTER`/`OVER`.

## pg_dump fidelity

`CREATE`/`ALTER PROPERTY GRAPH` match what `pg_dump` actually emits — the `pg_get_propgraphdef` body with one element per line, terminated with a semicolon. Verified against a real PostgreSQL 19beta2 server.

## Test harness

- `compose.yaml` stands up a throwaway `postgres:19beta2` container that loads `tests/fixtures/pg_dump/schema.sql` on boot. `generate.sh` captures the deparser output into the `pg_dump` idempotency fixtures, replacing the previous local `initdb`/`pg_ctl` path — now only Docker is required (`just gen-pgdump-fixtures`).
- New idempotency fixtures for property graphs, `IGNORE NULLS`, and `WITHIN GROUP`. The existing 29 view/function fixtures regenerate byte-identical under PG19.
- Dedicated per-style smoke assertions for `GRAPH_TABLE`, `CREATE PROPERTY GRAPH`, and `ALTER PROPERTY GRAPH` (table-driven, exact-match, with idempotency checks on the multi-line blocks).

## Notes

- No new general-purpose SQL operators in PG19; the grammar's new `->`/`|` are SQL/PGQ path/label operators, and operators are formatted generically (verbatim passthrough) so they are style-independent.
- The `:` label shorthand (`(a:Person)`) is rejected by PG19 itself — only `(a IS Person)` is valid, which formats cleanly.

## Test plan

- [x] `cargo test` — full suite green (smoke suite 23 tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `just gen-pgdump-fixtures` reproduces committed fixtures byte-for-byte
- [x] Feature acceptance verified directly against PostgreSQL 19beta2

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL 19 formatting support for property graphs (CREATE/ALTER PROPERTY GRAPH), graph queries (GRAPH_TABLE), and additional aggregate/window clause combinations (WITHIN GROUP, FILTER, RESPECT/IGNORE NULLS).
  * Added support for `UPDATE`/`DELETE ... FOR PORTION OF ...` targets (including optional `FROM ... TO ...` forms).
* **Bug Fixes**
  * Improved SQL formatting preservation and casing/order for `FILTER`/`WITHIN GROUP`/`RESPECT|IGNORE NULLS` alongside `OVER`.
* **Tests**
  * Expanded PG19 smoke/regression coverage for formatting across multiple output styles.
* **Chores**
  * Updated fixture generation to use a temporary Docker-based PostgreSQL 19 environment and refreshed related fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->